### PR TITLE
Signal handling

### DIFF
--- a/consume_test.go
+++ b/consume_test.go
@@ -69,7 +69,7 @@ func TestParseOffsets(t *testing.T) {
 		},
 		{
 			testName: "all-with-space",
-			input: "	all ",
+			input:    "	all ",
 			expected: map[int32]interval{
 				-1: {
 					start: offset{relative: true, start: sarama.OffsetOldest},


### PR DESCRIPTION
- Handle SIGINT and SIGTERM signals for graceful shutdown
- Properly close offset managers to ensure offsets are saved
- Wait for all consumer goroutines to finish before exit
- Fix issue where Ctrl-C would prevent offset saving in resume mode