### PR TITLE
Update GitHub Actions workflow to latest versions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,20 +15,12 @@ jobs:
     steps:
 
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
-        go-version: ^1.21
+        go-version: ^1.24
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-
-    - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
-        if [ -f Gopkg.toml ]; then
-            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-            dep ensure
-        fi
+      uses: actions/checkout@v4
 
     - name: Bring up containers
       run: docker compose -f test-dependencies.yml up -d


### PR DESCRIPTION
- Update Go version to 1.24
- Update actions/setup-go to v5
- Update actions/checkout to v4
- Remove unnecessary Get dependencies step (Go modules handles this automatically)

🤖 Generated with [Claude Code](https://claude.ai/code)