### PR TITLE
Add timestamp-based offset support to consume command

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Some reasons why you might be interested:
 
 * Consume messages on specific partitions between specific offsets.
+* **Time-based offset consumption**: Start consuming from specific timestamps (RFC3339), relative times (e.g., `-1h`, `+30m`), or current time (`now`).
 * Display topic information (e.g., with partition offset and leader info).
 * Modify consumer group offsets (e.g., resetting or manually setting offsets per topic and per partition).
 * JSON output for easy consumption with tools like [kp](https://github.com/echojc/kp) or [jq](https://stedolan.github.io/jq/).
@@ -128,6 +129,34 @@ $ kt consume -topic actor-news -offsets all=newest-1:
 }
 ^Creceived interrupt - shutting down
 shutting down partition consumer for partition 0
+```
+</details>
+
+<details><summary>Consume messages from specific timestamp</summary>
+
+```sh
+# Start from current time (equivalent to newest)
+$ kt consume -topic actor-news -offsets now
+
+# Start from specific absolute time (RFC3339 format)
+$ kt consume -topic actor-news -offsets "2023-12-01T15:00:00Z"
+
+# Start from 1 hour ago
+$ kt consume -topic actor-news -offsets "-1h"
+
+# Start from 30 minutes in the future
+$ kt consume -topic actor-news -offsets "+30m"
+```
+</details>
+
+<details><summary>Mix partition-specific and timestamp-based offsets</summary>
+
+```sh
+# Partition 0 from oldest, others from 1 hour ago
+$ kt consume -topic actor-news -offsets "0=oldest,-1h"
+
+# Specific partitions with absolute timestamp
+$ kt consume -topic actor-news -offsets "1=2023-12-01T15:00:00Z,2=now"
 ```
 </details>
 

--- a/consume.go
+++ b/consume.go
@@ -117,14 +117,24 @@ func (h *ConsumerGroupHandler) ConsumeClaim(session sarama.ConsumerGroupSession,
 }
 
 type offset struct {
-	relative bool
-	start    int64
-	diff     int64
+	relative  bool
+	start     int64
+	diff      int64
+	timestamp bool // true if start represents a timestamp in milliseconds that needs resolution
 }
 
 func (cmd *consumeCmd) resolveOffset(o offset, partition int32) (int64, error) {
 	if !o.relative {
 		return o.start, nil
+	}
+
+	// Handle timestamp-based offsets
+	if o.timestamp {
+		res, err := cmd.resolveTimestampOffset(o.start, partition)
+		if err != nil {
+			return 0, err
+		}
+		return res + o.diff, nil
 	}
 
 	var (
@@ -152,6 +162,52 @@ func (cmd *consumeCmd) resolveOffset(o offset, partition int32) (int64, error) {
 	}
 
 	return o.start + o.diff, nil
+}
+
+// resolveTimestampOffset resolves a timestamp in milliseconds to the closest Kafka offset
+func (cmd *consumeCmd) resolveTimestampOffset(timestampMs int64, partition int32) (int64, error) {
+	// Create an offset request to find the offset for the given timestamp
+	offsetRequest := &sarama.OffsetRequest{
+		Version: 1, // Version 1 supports timestamp-based offset lookup
+	}
+	
+	// Add the partition and timestamp to the request
+	offsetRequest.AddBlock(cmd.topic, partition, timestampMs, 1)
+	
+	// Get a broker to send the request to
+	broker, err := cmd.client.Leader(cmd.topic, partition)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get leader broker for topic %s partition %d: %v", cmd.topic, partition, err)
+	}
+	
+	// Send the offset request
+	offsetResponse, err := broker.GetAvailableOffsets(offsetRequest)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get offset for timestamp %d: %v", timestampMs, err)
+	}
+	
+	// Extract the offset from the response
+	topicOffsets, ok := offsetResponse.Blocks[cmd.topic]
+	if !ok {
+		return 0, fmt.Errorf("no offset response for topic %s", cmd.topic)
+	}
+	
+	partitionOffset, ok := topicOffsets[partition]
+	if !ok {
+		return 0, fmt.Errorf("no offset response for partition %d", partition)
+	}
+	
+	if partitionOffset.Err != sarama.ErrNoError {
+		return 0, fmt.Errorf("error in offset response: %v", partitionOffset.Err)
+	}
+	
+	// If the timestamp is too old, return the oldest available offset
+	if partitionOffset.Offset == -1 {
+		debugf(cmd, "timestamp %d is older than available messages, using oldest offset for partition %d\n", timestampMs, partition)
+		return cmd.client.GetOffset(cmd.topic, partition, sarama.OffsetOldest)
+	}
+	
+	return partitionOffset.Offset, nil
 }
 
 type interval struct {
@@ -309,14 +365,31 @@ func parseOffsets(str string) (map[int32]interval, error) {
 	return result, nil
 }
 
-// parseRelativeOffset parses a relative offset, such as "oldest", "newest-30", or "+20".
+// parseRelativeOffset parses a relative offset, such as "oldest", "newest-30", "+20", or time strings.
 func parseRelativeOffset(s string) (offset, error) {
 	o, ok := parseNamedRelativeOffset(s)
 	if ok {
 		return o, nil
 	}
+	
+	// Check for time string first, before checking for +/- operators
+	// This handles RFC3339 times and relative durations
+	// Only try parsing as time if it looks like RFC3339 (contains T) or has valid duration syntax
+	if strings.Contains(s, "T") && strings.Contains(s, ":") {
+		// RFC3339 timestamp
+		if t, err := parseTimeString(s); err == nil {
+			return offset{relative: true, start: t.UnixMilli(), timestamp: true}, nil
+		}
+	} else if (strings.HasPrefix(s, "+") || strings.HasPrefix(s, "-")) && (strings.Contains(s, "h") || strings.Contains(s, "m") || strings.Contains(s, "s")) {
+		// Relative duration like +1h, -30m, +5s
+		if t, err := parseTimeString(s); err == nil {
+			return offset{relative: true, start: t.UnixMilli(), timestamp: true}, nil
+		}
+	}
+	
 	i := strings.IndexAny(s, "+-")
 	if i == -1 {
+		// If no +/- and not a time string, it's invalid
 		return offset{}, fmt.Errorf("invalid offset %q", s)
 	}
 	switch {
@@ -355,6 +428,9 @@ func parseNamedRelativeOffset(s string) (offset, bool) {
 		return oldestOffset(), true
 	case "resume":
 		return offset{relative: true, start: offsetResume}, true
+	case "now":
+		// "now" means current time, which will be resolved to timestamp-based offset
+		return offset{relative: true, start: time.Now().UnixMilli(), timestamp: true}, true
 	default:
 		return offset{}, false
 	}
@@ -373,6 +449,22 @@ func parseInterval(s string) (interval, error) {
 			end:   lastOffset(),
 		}, nil
 	}
+	
+	// Check if the entire string is an RFC3339 timestamp before splitting on colons
+	if strings.Contains(s, "T") && strings.Contains(s, ":") {
+		if _, err := parseTimeString(s); err == nil {
+			// It's a valid timestamp, treat as start offset only
+			startOff, err := parseIntervalPart(s, oldestOffset())
+			if err != nil {
+				return interval{}, err
+			}
+			return interval{
+				start: startOff,
+				end:   lastOffset(),
+			}, nil
+		}
+	}
+	
 	var start, end string
 	i := strings.Index(s, ":")
 	if i == -1 {

--- a/consume_test.go
+++ b/consume_test.go
@@ -23,8 +23,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "",
 			expected: map[int32]interval{
 				-1: {
-					start: offset{relative: true, start: sarama.OffsetOldest},
-					end:   offset{start: 1<<63 - 1},
+					start: offset{relative: true, start: sarama.OffsetOldest, timestamp: false},
+					end:   offset{start: 1<<63 - 1, timestamp: false},
 				},
 			},
 		},
@@ -33,8 +33,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    ",",
 			expected: map[int32]interval{
 				-1: {
-					start: offset{relative: true, start: sarama.OffsetOldest},
-					end:   offset{start: 1<<63 - 1},
+					start: offset{relative: true, start: sarama.OffsetOldest, timestamp: false},
+					end:   offset{start: 1<<63 - 1, timestamp: false},
 				},
 			},
 		},
@@ -43,8 +43,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "all",
 			expected: map[int32]interval{
 				-1: {
-					start: offset{relative: true, start: sarama.OffsetOldest},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: offset{relative: true, start: sarama.OffsetOldest, timestamp: false},
+					end:   offset{relative: false, start: 1<<63 - 1, timestamp: false},
 				},
 			},
 		},
@@ -53,8 +53,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "oldest",
 			expected: map[int32]interval{
 				-1: {
-					start: offset{relative: true, start: sarama.OffsetOldest},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: offset{relative: true, start: sarama.OffsetOldest, timestamp: false},
+					end:   offset{relative: false, start: 1<<63 - 1, timestamp: false},
 				},
 			},
 		},
@@ -63,8 +63,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "resume",
 			expected: map[int32]interval{
 				-1: {
-					start: offset{relative: true, start: offsetResume},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: offset{relative: true, start: offsetResume, timestamp: false},
+					end:   offset{relative: false, start: 1<<63 - 1, timestamp: false},
 				},
 			},
 		},
@@ -73,8 +73,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "	all ",
 			expected: map[int32]interval{
 				-1: {
-					start: offset{relative: true, start: sarama.OffsetOldest},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: offset{relative: true, start: sarama.OffsetOldest, timestamp: false},
+					end:   offset{relative: false, start: 1<<63 - 1, timestamp: false},
 				},
 			},
 		},
@@ -83,8 +83,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "all=+0:",
 			expected: map[int32]interval{
 				-1: {
-					start: offset{relative: true, start: sarama.OffsetOldest, diff: 0},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: offset{relative: true, start: sarama.OffsetOldest, diff: 0, timestamp: false},
+					end:   offset{relative: false, start: 1<<63 - 1, timestamp: false},
 				},
 			},
 		},
@@ -93,16 +93,16 @@ func TestParseOffsets(t *testing.T) {
 			input:    "1,2,4",
 			expected: map[int32]interval{
 				1: {
-					start: offset{relative: true, start: sarama.OffsetOldest},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: offset{relative: true, start: sarama.OffsetOldest, timestamp: false},
+					end:   offset{relative: false, start: 1<<63 - 1, timestamp: false},
 				},
 				2: {
-					start: offset{relative: true, start: sarama.OffsetOldest},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: offset{relative: true, start: sarama.OffsetOldest, timestamp: false},
+					end:   offset{relative: false, start: 1<<63 - 1, timestamp: false},
 				},
 				4: {
-					start: offset{relative: true, start: sarama.OffsetOldest},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: offset{relative: true, start: sarama.OffsetOldest, timestamp: false},
+					end:   offset{relative: false, start: 1<<63 - 1, timestamp: false},
 				},
 			},
 		},
@@ -111,8 +111,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=",
 			expected: map[int32]interval{
 				0: {
-					start: offset{relative: true, start: sarama.OffsetOldest},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: offset{relative: true, start: sarama.OffsetOldest, timestamp: false},
+					end:   offset{relative: false, start: 1<<63 - 1, timestamp: false},
 				},
 			},
 		},
@@ -121,8 +121,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=1",
 			expected: map[int32]interval{
 				0: {
-					start: offset{relative: false, start: 1},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: offset{relative: false, start: 1, timestamp: false},
+					end:   offset{relative: false, start: 1<<63 - 1, timestamp: false},
 				},
 			},
 		},
@@ -131,8 +131,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=1:",
 			expected: map[int32]interval{
 				0: {
-					start: offset{relative: false, start: 1},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: offset{relative: false, start: 1, timestamp: false},
+					end:   offset{relative: false, start: 1<<63 - 1, timestamp: false},
 				},
 			},
 		},
@@ -141,16 +141,16 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=4:,2=1:10,6",
 			expected: map[int32]interval{
 				0: {
-					start: offset{relative: false, start: 4},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: offset{relative: false, start: 4, timestamp: false},
+					end:   offset{relative: false, start: 1<<63 - 1, timestamp: false},
 				},
 				2: {
-					start: offset{relative: false, start: 1},
-					end:   offset{relative: false, start: 10},
+					start: offset{relative: false, start: 1, timestamp: false},
+					end:   offset{relative: false, start: 10, timestamp: false},
 				},
 				6: {
-					start: offset{relative: true, start: sarama.OffsetOldest},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: offset{relative: true, start: sarama.OffsetOldest, timestamp: false},
+					end:   offset{relative: false, start: 1<<63 - 1, timestamp: false},
 				},
 			},
 		},
@@ -159,8 +159,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=-1",
 			expected: map[int32]interval{
 				0: {
-					start: offset{relative: true, start: sarama.OffsetNewest, diff: -1},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: offset{relative: true, start: sarama.OffsetNewest, diff: -1, timestamp: false},
+					end:   offset{relative: false, start: 1<<63 - 1, timestamp: false},
 				},
 			},
 		},
@@ -169,8 +169,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=-1:",
 			expected: map[int32]interval{
 				0: {
-					start: offset{relative: true, start: sarama.OffsetNewest, diff: -1},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: offset{relative: true, start: sarama.OffsetNewest, diff: -1, timestamp: false},
+					end:   offset{relative: false, start: 1<<63 - 1, timestamp: false},
 				},
 			},
 		},
@@ -179,8 +179,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=resume-10",
 			expected: map[int32]interval{
 				0: {
-					start: offset{relative: true, start: offsetResume, diff: -10},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: offset{relative: true, start: offsetResume, diff: -10, timestamp: false},
+					end:   offset{relative: false, start: 1<<63 - 1, timestamp: false},
 				},
 			},
 		},
@@ -189,8 +189,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=+1",
 			expected: map[int32]interval{
 				0: {
-					start: offset{relative: true, start: sarama.OffsetOldest, diff: 1},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: offset{relative: true, start: sarama.OffsetOldest, diff: 1, timestamp: false},
+					end:   offset{relative: false, start: 1<<63 - 1, timestamp: false},
 				},
 			},
 		},
@@ -199,8 +199,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=+1:",
 			expected: map[int32]interval{
 				0: {
-					start: offset{relative: true, start: sarama.OffsetOldest, diff: 1},
-					end:   offset{relative: false, start: 1<<63 - 1},
+					start: offset{relative: true, start: sarama.OffsetOldest, diff: 1, timestamp: false},
+					end:   offset{relative: false, start: 1<<63 - 1, timestamp: false},
 				},
 			},
 		},
@@ -209,8 +209,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=+1:-1",
 			expected: map[int32]interval{
 				0: {
-					start: offset{relative: true, start: sarama.OffsetOldest, diff: 1},
-					end:   offset{relative: true, start: sarama.OffsetNewest, diff: -1},
+					start: offset{relative: true, start: sarama.OffsetOldest, diff: 1, timestamp: false},
+					end:   offset{relative: true, start: sarama.OffsetNewest, diff: -1, timestamp: false},
 				},
 			},
 		},
@@ -219,12 +219,12 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=+1:-1,all=1:10",
 			expected: map[int32]interval{
 				0: {
-					start: offset{relative: true, start: sarama.OffsetOldest, diff: 1},
-					end:   offset{relative: true, start: sarama.OffsetNewest, diff: -1},
+					start: offset{relative: true, start: sarama.OffsetOldest, diff: 1, timestamp: false},
+					end:   offset{relative: true, start: sarama.OffsetNewest, diff: -1, timestamp: false},
 				},
 				-1: {
-					start: offset{relative: false, start: 1, diff: 0},
-					end:   offset{relative: false, start: 10, diff: 0},
+					start: offset{relative: false, start: 1, diff: 0, timestamp: false},
+					end:   offset{relative: false, start: 10, diff: 0, timestamp: false},
 				},
 			},
 		},
@@ -233,8 +233,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=oldest:newest",
 			expected: map[int32]interval{
 				0: {
-					start: offset{relative: true, start: sarama.OffsetOldest, diff: 0},
-					end:   offset{relative: true, start: sarama.OffsetNewest, diff: 0},
+					start: offset{relative: true, start: sarama.OffsetOldest, diff: 0, timestamp: false},
+					end:   offset{relative: true, start: sarama.OffsetNewest, diff: 0, timestamp: false},
 				},
 			},
 		},
@@ -243,8 +243,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "0=oldest+10:newest-10",
 			expected: map[int32]interval{
 				0: {
-					start: offset{relative: true, start: sarama.OffsetOldest, diff: 10},
-					end:   offset{relative: true, start: sarama.OffsetNewest, diff: -10},
+					start: offset{relative: true, start: sarama.OffsetOldest, diff: 10, timestamp: false},
+					end:   offset{relative: true, start: sarama.OffsetNewest, diff: -10, timestamp: false},
 				},
 			},
 		},
@@ -253,8 +253,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "newest",
 			expected: map[int32]interval{
 				-1: {
-					start: offset{relative: true, start: sarama.OffsetNewest, diff: 0},
-					end:   offset{relative: false, start: 1<<63 - 1, diff: 0},
+					start: offset{relative: true, start: sarama.OffsetNewest, diff: 0, timestamp: false},
+					end:   offset{relative: false, start: 1<<63 - 1, diff: 0, timestamp: false},
 				},
 			},
 		},
@@ -263,8 +263,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "10",
 			expected: map[int32]interval{
 				10: {
-					start: offset{relative: true, start: sarama.OffsetOldest, diff: 0},
-					end:   offset{relative: false, start: 1<<63 - 1, diff: 0},
+					start: offset{relative: true, start: sarama.OffsetOldest, diff: 0, timestamp: false},
+					end:   offset{relative: false, start: 1<<63 - 1, diff: 0, timestamp: false},
 				},
 			},
 		},
@@ -273,8 +273,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "10:20",
 			expected: map[int32]interval{
 				-1: {
-					start: offset{start: 10},
-					end:   offset{start: 20},
+					start: offset{start: 10, timestamp: false},
+					end:   offset{start: 20, timestamp: false},
 				},
 			},
 		},
@@ -283,8 +283,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "10:",
 			expected: map[int32]interval{
 				-1: {
-					start: offset{start: 10},
-					end:   offset{start: 1<<63 - 1},
+					start: offset{start: 10, timestamp: false},
+					end:   offset{start: 1<<63 - 1, timestamp: false},
 				},
 			},
 		},
@@ -293,8 +293,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "all=newest:",
 			expected: map[int32]interval{
 				-1: {
-					start: offset{relative: true, start: sarama.OffsetNewest, diff: 0},
-					end:   offset{relative: false, start: 1<<63 - 1, diff: 0},
+					start: offset{relative: true, start: sarama.OffsetNewest, diff: 0, timestamp: false},
+					end:   offset{relative: false, start: 1<<63 - 1, diff: 0, timestamp: false},
 				},
 			},
 		},
@@ -303,8 +303,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "newest-10:",
 			expected: map[int32]interval{
 				-1: {
-					start: offset{relative: true, start: sarama.OffsetNewest, diff: -10},
-					end:   offset{relative: false, start: 1<<63 - 1, diff: 0},
+					start: offset{relative: true, start: sarama.OffsetNewest, diff: -10, timestamp: false},
+					end:   offset{relative: false, start: 1<<63 - 1, diff: 0, timestamp: false},
 				},
 			},
 		},
@@ -313,8 +313,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "oldest+10:",
 			expected: map[int32]interval{
 				-1: {
-					start: offset{relative: true, start: sarama.OffsetOldest, diff: 10},
-					end:   offset{relative: false, start: 1<<63 - 1, diff: 0},
+					start: offset{relative: true, start: sarama.OffsetOldest, diff: 10, timestamp: false},
+					end:   offset{relative: false, start: 1<<63 - 1, diff: 0, timestamp: false},
 				},
 			},
 		},
@@ -323,8 +323,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "-10:",
 			expected: map[int32]interval{
 				-1: {
-					start: offset{relative: true, start: sarama.OffsetNewest, diff: -10},
-					end:   offset{relative: false, start: 1<<63 - 1, diff: 0},
+					start: offset{relative: true, start: sarama.OffsetNewest, diff: -10, timestamp: false},
+					end:   offset{relative: false, start: 1<<63 - 1, diff: 0, timestamp: false},
 				},
 			},
 		},
@@ -333,8 +333,8 @@ func TestParseOffsets(t *testing.T) {
 			input:    "+10:",
 			expected: map[int32]interval{
 				-1: {
-					start: offset{relative: true, start: sarama.OffsetOldest, diff: 10},
-					end:   offset{relative: false, start: 1<<63 - 1, diff: 0},
+					start: offset{relative: true, start: sarama.OffsetOldest, diff: 10, timestamp: false},
+					end:   offset{relative: false, start: 1<<63 - 1, diff: 0, timestamp: false},
 				},
 			},
 		},
@@ -383,6 +383,60 @@ func TestParseOffsets(t *testing.T) {
 			input:       "2147483648=oldest",
 			expectedErr: `partition number "2147483648" is too large`,
 		},
+		{
+			testName: "time-absolute",
+			input:    "all=2023-12-01T15:00:00Z",
+			expected: map[int32]interval{
+				-1: {
+					start: offset{relative: true, start: 1701442800000, timestamp: true}, // 2023-12-01T15:00:00Z in millis
+					end:   offset{start: 1<<63 - 1, timestamp: false},
+				},
+			},
+		},
+		{
+			testName: "time-absolute-implicit-all",
+			input:    "2023-12-01T15:00:00Z",
+			expected: map[int32]interval{
+				-1: {
+					start: offset{relative: true, start: 1701442800000, timestamp: true}, // 2023-12-01T15:00:00Z in millis (implicit all)
+					end:   offset{start: 1<<63 - 1, timestamp: false},
+				},
+			},
+		},
+		{
+			testName: "time-now-implicit-all",
+			input:    "now",
+			expected: map[int32]interval{
+				-1: {
+					start: offset{relative: true, start: 0, timestamp: true}, // Will be set to current time during parsing
+					end:   offset{start: 1<<63 - 1, timestamp: false},
+				},
+			},
+		},
+		{
+			testName: "time-relative-implicit-all",
+			input:    "+1h",
+			expected: map[int32]interval{
+				-1: {
+					start: offset{relative: true, start: 0, timestamp: true}, // Will be set to current time + 1h
+					end:   offset{start: 1<<63 - 1, timestamp: false},
+				},
+			},
+		},
+		{
+			testName: "mixed-partition-specific-and-implicit",
+			input:    "0=oldest,+1h",
+			expected: map[int32]interval{
+				0: {
+					start: offset{relative: true, start: sarama.OffsetOldest, timestamp: false},
+					end:   offset{start: 1<<63 - 1, timestamp: false},
+				},
+				-1: {
+					start: offset{relative: true, start: 0, timestamp: true}, // +1h for all other partitions
+					end:   offset{start: 1<<63 - 1, timestamp: false},
+				},
+			},
+		},
 	}
 
 	for _, d := range data {
@@ -397,7 +451,40 @@ func TestParseOffsets(t *testing.T) {
 				}
 				return
 			}
-			if !reflect.DeepEqual(actual, d.expected) {
+			
+			// Special handling for dynamic timestamp tests
+			if strings.Contains(d.testName, "now") || strings.Contains(d.testName, "relative-implicit") || strings.Contains(d.testName, "mixed-partition") {
+				// Check structure is correct but don't compare exact timestamp values
+				if len(actual) != len(d.expected) {
+					t.Errorf("Expected %d intervals, got %d", len(d.expected), len(actual))
+					return
+				}
+				for partition, expectedInterval := range d.expected {
+					actualInterval, ok := actual[partition]
+					if !ok {
+						t.Errorf("Missing partition %d in actual result", partition)
+						continue
+					}
+					// For timestamp offsets, just check the flags are correct
+					if expectedInterval.start.timestamp {
+						if !actualInterval.start.relative || !actualInterval.start.timestamp {
+							t.Errorf("Partition %d start should be relative and timestamp", partition)
+						}
+						if actualInterval.start.start == 0 {
+							t.Errorf("Partition %d start timestamp should not be zero", partition)
+						}
+					} else {
+						// Non-timestamp offsets should match exactly
+						if !reflect.DeepEqual(actualInterval.start, expectedInterval.start) {
+							t.Errorf("Partition %d start mismatch: expected %+v, got %+v", partition, expectedInterval.start, actualInterval.start)
+						}
+					}
+					// End should always match exactly
+					if !reflect.DeepEqual(actualInterval.end, expectedInterval.end) {
+						t.Errorf("Partition %d end mismatch: expected %+v, got %+v", partition, expectedInterval.end, actualInterval.end)
+					}
+				}
+			} else if !reflect.DeepEqual(actual, d.expected) {
 				t.Errorf(
 					`
 Expected: %+v, err=%v
@@ -415,6 +502,53 @@ Input:    %v
 	}
 }
 
+func TestTimestampOffsetParsing(t *testing.T) {
+	now := time.Now()
+	
+	// Test "now" parsing
+	result, err := parseOffsets("all=now")
+	if err != nil {
+		t.Fatalf("unexpected error parsing 'now': %v", err)
+	}
+	
+	if len(result) != 1 {
+		t.Fatalf("expected 1 interval, got %d", len(result))
+	}
+	
+	interval, ok := result[-1]
+	if !ok {
+		t.Fatal("expected interval for partition -1")
+	}
+	
+	if !interval.start.relative || !interval.start.timestamp {
+		t.Errorf("expected start to be relative and timestamp, got relative=%v timestamp=%v", interval.start.relative, interval.start.timestamp)
+	}
+	
+	// Check that the timestamp is close to current time (within 1 second)
+	actualTime := time.Unix(0, interval.start.start*int64(time.Millisecond))
+	if actualTime.Sub(now).Abs() > time.Second {
+		t.Errorf("'now' timestamp %v should be close to test start time %v", actualTime, now)
+	}
+	
+	// Test relative duration parsing
+	result, err = parseOffsets("all=+1h")
+	if err != nil {
+		t.Fatalf("unexpected error parsing '+1h': %v", err)
+	}
+	
+	interval = result[-1]
+	if !interval.start.relative || !interval.start.timestamp {
+		t.Errorf("expected start to be relative and timestamp for +1h")
+	}
+	
+	// Check that +1h is about 1 hour in the future
+	actualTime = time.Unix(0, interval.start.start*int64(time.Millisecond))
+	expectedTime := now.Add(time.Hour)
+	if actualTime.Sub(expectedTime).Abs() > time.Second {
+		t.Errorf("+1h timestamp %v should be about 1 hour from test start time %v", actualTime, expectedTime)
+	}
+}
+
 func TestFindPartitionsToConsume(t *testing.T) {
 	data := []struct {
 		topic    string
@@ -425,7 +559,7 @@ func TestFindPartitionsToConsume(t *testing.T) {
 		{
 			topic: "a",
 			offsets: map[int32]interval{
-				10: {offset{false, 2, 0}, offset{false, 4, 0}},
+				10: {offset{relative: false, start: 2, diff: 0, timestamp: false}, offset{relative: false, start: 4, diff: 0, timestamp: false}},
 			},
 			consumer: tConsumer{
 				topics:              []string{"a"},
@@ -441,7 +575,7 @@ func TestFindPartitionsToConsume(t *testing.T) {
 		{
 			topic: "a",
 			offsets: map[int32]interval{
-				-1: {offset{false, 3, 0}, offset{false, 41, 0}},
+				-1: {offset{relative: false, start: 3, diff: 0, timestamp: false}, offset{relative: false, start: 41, diff: 0, timestamp: false}},
 			},
 			consumer: tConsumer{
 				topics:              []string{"a"},
@@ -497,7 +631,7 @@ func TestConsume(t *testing.T) {
 	target.topic = "hans"
 	target.brokers = []string{"localhost:9092"}
 	target.offsets = map[int32]interval{
-		-1: {start: offset{false, 1, 0}, end: offset{false, 5, 0}},
+		-1: {start: offset{relative: false, start: 1, diff: 0, timestamp: false}, end: offset{relative: false, start: 5, diff: 0, timestamp: false}},
 	}
 
 	go target.consume(partitions)


### PR DESCRIPTION
Enhance the -offsets flag to support time-based consumption, allowing users to start consuming from specific timestamps instead of just numeric offsets.

New features:
- RFC3339 absolute timestamps: "2023-12-01T15:00:00Z"
- Current time: "now"
- Relative durations: "+1h", "-30m", "+5s"
- Simplified syntax: "now" instead of "all=now"
- Mixed partition/timestamp specs: "0=oldest,+1h"

Implementation:
- Add timestamp field to offset struct for identification
- Implement resolveTimestampOffset() using Kafka OffsetRequest API
- Enhanced parseRelativeOffset() to handle time strings
- Updated parseInterval() to correctly handle RFC3339 timestamps
- Comprehensive test coverage for all time formats

The feature uses Kafka's built-in timestamp-to-offset resolution via sarama.OffsetRequest, ensuring accurate offset mapping for any timestamp within the topic's retention period.

🤖 Generated with [Claude Code](https://claude.ai/code)