### PR TITLE
Add -quiet flag to produce command for silent operation

### DIFF
--- a/common.go
+++ b/common.go
@@ -162,6 +162,13 @@ func print(in <-chan printContext, pretty bool) {
 	}
 }
 
+func quietPrint(in <-chan printContext) {
+	for {
+		ctx := <-in
+		close(ctx.done)
+	}
+}
+
 func quitf(msg string, args ...interface{}) {
 	exitf(0, msg, args...)
 }


### PR DESCRIPTION
Add quiet mode that suppresses output on successful message production while still showing errors. This is useful for bulk data loading scenarios where thousands of success confirmations are not needed.

Implementation:
- Add -quiet flag to produce command arguments
- Create quietPrint() function that consumes output channels without processing
- Always create output channel for consistent behavior and safety
- Route to appropriate print function based on quiet mode

Benefits:
- Eliminates verbose output during bulk operations
- Reduces CPU overhead (no JSON marshaling in quiet mode)
- Maintains error reporting functionality
- Prevents potential nil channel panics in future modifications

🤖 Generated with [Claude Code](https://claude.ai/code)