### PR TITLE
Fix output buffering effectiveness by removing unnecessary flushes

### DIFF
--- a/common.go
+++ b/common.go
@@ -156,8 +156,8 @@ func print(in <-chan printContext, pretty bool) {
 			failf("failed to marshal output %#v, err=%v", ctx.output, err)
 		}
 
-		fmt.Fprintln(stdoutWriter, string(buf))
-		flushOutput()
+		stdoutWriter.Write(buf)
+		stdoutWriter.Write([]byte{'\n'})
 		close(ctx.done)
 	}
 }


### PR DESCRIPTION
The adaptive buffering in PR #15 had a significant issue: it was calling flushOutput() after every message, which negated most buffering benefits.

Changes:
- Remove flushOutput() call from print() function per message
- Replace fmt.Fprintln() with direct Write() calls to avoid string conversion
- Let bufio.Writer handle automatic flushing when buffer is full
- Keep program exit flush for final output

This fixes the buffering effectiveness issue where each message was being flushed immediately, making the buffering nearly pointless for performance.

🤖 Generated with [Claude Code](https://claude.ai/code)