### PR TITLE
Add periodic flush for pipeline compatibility while maintaining bufering.

### DIFF
--- a/common.go
+++ b/common.go
@@ -20,6 +20,11 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
+const (
+	// Periodic flush interval for buffered output to pipes/files
+	flushInterval = 250 * time.Millisecond
+)
+
 var (
 	stdoutWriter   io.Writer
 	bufferedWriter *bufio.Writer
@@ -35,6 +40,16 @@ func setupOutputBuffering() {
 	} else {
 		bufferedWriter = bufio.NewWriter(os.Stdout)
 		stdoutWriter = bufferedWriter
+		// Start periodic flushing for non-tty output
+		go periodicFlush()
+	}
+}
+
+func periodicFlush() {
+	ticker := time.NewTicker(flushInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		flushOutput()
 	}
 }
 


### PR DESCRIPTION

Implement periodic flushing for non-tty output to solve pipeline processing issues while preserving buffering benefits for bulk operations.

Changes:
- Add periodic flush goroutine with 250ms interval for non-tty output
- Add flushInterval constant for maintainability
- Remove per-message flush calls to restore buffering effectiveness
- Maintain immediate output for tty (interactive) sessions

This solves the pipeline delay issue where buffered output would not reach the next command in a pipeline until the buffer was full, while still providing significant performance benefits for bulk operations.

🤖 Generated with [Claude Code](https://claude.ai/code)