### PR TITLE
Add jq filtering support with -jq and -raw flags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,9 @@ require (
 	github.com/IBM/sarama v1.45.2
 	github.com/davecgh/go-spew v1.1.1
 	github.com/goccy/go-json v0.10.4
+	github.com/itchyny/gojq v0.12.17
 	github.com/stretchr/testify v1.10.0
-	golang.org/x/crypto v0.40.0
+	golang.org/x/term v0.33.0
 )
 
 require (
@@ -18,6 +19,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
+	github.com/itchyny/timefmt-go v0.1.6 // indirect
 	github.com/jcmturner/aescts/v2 v2.0.0 // indirect
 	github.com/jcmturner/dnsutils/v2 v2.0.0 // indirect
 	github.com/jcmturner/gofork v1.7.6 // indirect
@@ -29,8 +31,8 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
+	golang.org/x/crypto v0.40.0 // indirect
 	golang.org/x/net v0.42.0 // indirect
 	golang.org/x/sys v0.34.0 // indirect
-	golang.org/x/term v0.33.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,10 @@ github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/itchyny/gojq v0.12.17 h1:8av8eGduDb5+rvEdaOO+zQUjA04MS0m3Ps8HiD+fceg=
+github.com/itchyny/gojq v0.12.17/go.mod h1:WBrEMkgAfAGO1LUcGOckBl5O726KPp+OlkKug0I/FEY=
+github.com/itchyny/timefmt-go v0.1.6 h1:ia3s54iciXDdzWzwaVKXZPbiXzxxnv1SPGFfM/myJ5Q=
+github.com/itchyny/timefmt-go v0.1.6/go.mod h1:RRDZYC5s9ErkjQvTvvU7keJjxUYzIISJGxm9/mAERQg=
 github.com/jcmturner/aescts/v2 v2.0.0 h1:9YKLH6ey7H4eDBXW8khjYslgyqG2xZikXP0EQFKrle8=
 github.com/jcmturner/aescts/v2 v2.0.0/go.mod h1:AiaICIRyfYg35RUkr8yESTqvSy7csK90qZ5xfvvsoNs=
 github.com/jcmturner/dnsutils/v2 v2.0.0 h1:lltnkeZGL0wILNvrNiVCR6Ro5PGU/SeBvVO/8c/iPbo=

--- a/group_test.go
+++ b/group_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"testing"
+
+	json "github.com/goccy/go-json"
+)
+
+func TestGroupJqFlags(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		expectJq    string
+		expectRaw   bool
+		expectError bool
+	}{
+		{
+			name:        "no jq flags",
+			args:        []string{"-group", "test-group"},
+			expectJq:    "",
+			expectRaw:   false,
+			expectError: false,
+		},
+		{
+			name:        "jq flag only",
+			args:        []string{"-group", "test-group", "-jq", ".name"},
+			expectJq:    ".name",
+			expectRaw:   false,
+			expectError: false,
+		},
+		{
+			name:        "raw flag only",
+			args:        []string{"-group", "test-group", "-raw"},
+			expectJq:    "",
+			expectRaw:   true,
+			expectError: false,
+		},
+		{
+			name:        "both jq and raw flags",
+			args:        []string{"-group", "test-group", "-jq", ".offsets[0].partition", "-raw"},
+			expectJq:    ".offsets[0].partition",
+			expectRaw:   true,
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &groupCmd{}
+			cmd.parseArgs(tt.args)
+			if cmd.jq != tt.expectJq {
+				t.Errorf("expected jq %q, got %q", tt.expectJq, cmd.jq)
+			}
+			if cmd.raw != tt.expectRaw {
+				t.Errorf("expected raw %v, got %v", tt.expectRaw, cmd.raw)
+			}
+		})
+	}
+}
+
+func TestGroupToMap(t *testing.T) {
+	offset1 := int64(100)
+	lag1 := int64(10)
+	offset2 := int64(200)
+	lag2 := int64(20)
+
+	g := group{
+		Name:  "test-group",
+		Topic: "test-topic",
+		Offsets: []groupOffset{
+			{Partition: 0, Offset: &offset1, Lag: &lag1},
+			{Partition: 1, Offset: &offset2, Lag: &lag2},
+		},
+	}
+
+	result := g.ToMap()
+
+	// Verify structure without comparing pointer addresses
+	if result["name"] != "test-group" {
+		t.Errorf("expected name test-group, got %v", result["name"])
+	}
+	if result["topic"] != "test-topic" {
+		t.Errorf("expected topic test-topic, got %v", result["topic"])
+	}
+
+	offsets, ok := result["offsets"].([]any)
+	if !ok || len(offsets) != 2 {
+		t.Errorf("expected 2 offsets, got %v", result["offsets"])
+		return
+	}
+
+	// Check first offset
+	offset0, ok := offsets[0].(map[string]any)
+	if !ok {
+		t.Errorf("expected first offset to be map, got %T", offsets[0])
+		return
+	}
+	if offset0["partition"] != int32(0) {
+		t.Errorf("expected partition 0, got %v", offset0["partition"])
+	}
+	if offset0["offset"] != offset1 {
+		t.Errorf("expected offset %d, got %v", offset1, offset0["offset"])
+	}
+	if offset0["lag"] != lag1 {
+		t.Errorf("expected lag %d, got %v", lag1, offset0["lag"])
+	}
+}
+
+func TestGroupOffsetToMap(t *testing.T) {
+	offset := int64(100)
+	lag := int64(10)
+
+	o := groupOffset{
+		Partition: 0,
+		Offset:    &offset,
+		Lag:       &lag,
+	}
+
+	result := o.ToMap()
+	expected := map[string]any{
+		"partition": int32(0),
+		"offset":    offset,
+		"lag":       lag,
+	}
+
+	// Compare as JSON to ensure equivalence regardless of Go object structure
+	expectedJSON, err := json.Marshal(expected)
+	if err != nil {
+		t.Fatalf("failed to marshal expected: %v", err)
+	}
+	resultJSON, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("failed to marshal result: %v", err)
+	}
+
+	if string(expectedJSON) != string(resultJSON) {
+		t.Errorf("JSON mismatch:\nexpected: %s\nactual:   %s", expectedJSON, resultJSON)
+	}
+}
+
+func TestGroupOffsetToMapWithNils(t *testing.T) {
+	o := groupOffset{
+		Partition: 1,
+		Offset:    nil,
+		Lag:       nil,
+	}
+
+	result := o.ToMap()
+	expected := map[string]any{
+		"partition": int32(1),
+		"offset":    (*int64)(nil),
+		"lag":       (*int64)(nil),
+	}
+
+	// Compare as JSON to ensure equivalence regardless of Go object structure
+	expectedJSON, err := json.Marshal(expected)
+	if err != nil {
+		t.Fatalf("failed to marshal expected: %v", err)
+	}
+	resultJSON, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("failed to marshal result: %v", err)
+	}
+
+	if string(expectedJSON) != string(resultJSON) {
+		t.Errorf("JSON mismatch:\nexpected: %s\nactual:   %s", expectedJSON, resultJSON)
+	}
+}

--- a/topic_test.go
+++ b/topic_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"reflect"
 	"testing"
+
+	json "github.com/goccy/go-json"
 )
 
 func TestTopicParseArgs(t *testing.T) {
@@ -46,5 +48,141 @@ func TestTopicParseArgs(t *testing.T) {
 			target.brokers,
 		)
 		return
+	}
+}
+
+func TestTopicJqFlags(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		expectJq    string
+		expectRaw   bool
+		expectError bool
+	}{
+		{
+			name:        "no jq flags",
+			args:        []string{},
+			expectJq:    "",
+			expectRaw:   false,
+			expectError: false,
+		},
+		{
+			name:        "jq flag only",
+			args:        []string{"-jq", ".name"},
+			expectJq:    ".name",
+			expectRaw:   false,
+			expectError: false,
+		},
+		{
+			name:        "raw flag only",
+			args:        []string{"-raw"},
+			expectJq:    "",
+			expectRaw:   true,
+			expectError: false,
+		},
+		{
+			name:        "both jq and raw flags",
+			args:        []string{"-jq", ".partitions[0].id", "-raw"},
+			expectJq:    ".partitions[0].id",
+			expectRaw:   true,
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &topicCmd{}
+			cmd.parseArgs(tt.args)
+			if cmd.jq != tt.expectJq {
+				t.Errorf("expected jq %q, got %q", tt.expectJq, cmd.jq)
+			}
+			if cmd.raw != tt.expectRaw {
+				t.Errorf("expected raw %v, got %v", tt.expectRaw, cmd.raw)
+			}
+		})
+	}
+}
+
+func TestTopicToMap(t *testing.T) {
+	topic := topic{
+		Name: "test-topic",
+		Partitions: []partition{
+			{Id: 0, OldestOffset: 100, NewestOffset: 200, Leader: "1", Replicas: []int32{1, 2}, ISRs: []int32{1, 2}},
+			{Id: 1, OldestOffset: 150, NewestOffset: 250, Leader: "2", Replicas: []int32{2, 3}, ISRs: []int32{2}},
+		},
+		Config: map[string]string{"retention.ms": "604800000"},
+	}
+
+	result := topic.ToMap()
+	expected := map[string]any{
+		"name": "test-topic",
+		"partitions": []map[string]any{
+			{
+				"id":       int32(0),
+				"oldest":   int64(100),
+				"newest":   int64(200),
+				"leader":   "1",
+				"replicas": []int32{1, 2},
+				"isrs":     []int32{1, 2},
+			},
+			{
+				"id":       int32(1),
+				"oldest":   int64(150),
+				"newest":   int64(250),
+				"leader":   "2",
+				"replicas": []int32{2, 3},
+				"isrs":     []int32{2},
+			},
+		},
+		"config": map[string]string{"retention.ms": "604800000"},
+	}
+
+	// Compare as JSON to ensure equivalence regardless of Go object structure
+	expectedJSON, err := json.Marshal(expected)
+	if err != nil {
+		t.Fatalf("failed to marshal expected: %v", err)
+	}
+	resultJSON, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("failed to marshal result: %v", err)
+	}
+
+	if string(expectedJSON) != string(resultJSON) {
+		t.Errorf("JSON mismatch:\nexpected: %s\nactual:   %s", expectedJSON, resultJSON)
+	}
+}
+
+func TestPartitionToMap(t *testing.T) {
+	p := partition{
+		Id:           0,
+		OldestOffset: 100,
+		NewestOffset: 200,
+		Leader:       "1",
+		Replicas:     []int32{1, 2, 3},
+		ISRs:         []int32{1, 2},
+	}
+
+	result := p.ToMap()
+	expected := map[string]any{
+		"id":       int32(0),
+		"oldest":   int64(100),
+		"newest":   int64(200),
+		"leader":   "1",
+		"replicas": []int32{1, 2, 3},
+		"isrs":     []int32{1, 2},
+	}
+
+	// Compare as JSON to ensure equivalence regardless of Go object structure
+	expectedJSON, err := json.Marshal(expected)
+	if err != nil {
+		t.Fatalf("failed to marshal expected: %v", err)
+	}
+	resultJSON, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("failed to marshal result: %v", err)
+	}
+
+	if string(expectedJSON) != string(resultJSON) {
+		t.Errorf("JSON mismatch:\nexpected: %s\nactual:   %s", expectedJSON, resultJSON)
 	}
 }


### PR DESCRIPTION
- Add -jq flag for applying jq filters to output
- Add -raw flag for unquoted string output (like jq -r)
- Implement ToMap methods for jq compatibility
- Add comprehensive test coverage

🤖 Generated with [Claude Code](https://claude.ai/code)