### PR TITLE
Remove deprecated BuildNameToCertificate calls

### DIFF
--- a/common.go
+++ b/common.go
@@ -428,8 +428,6 @@ func setupAuthTLS1Way(auth authConfig, saramaCfg *sarama.Config) error {
 	}
 
 	tlsCfg := &tls.Config{RootCAs: caPool}
-	tlsCfg.BuildNameToCertificate()
-
 	saramaCfg.Net.TLS.Config = tlsCfg
 	return nil
 }
@@ -456,8 +454,6 @@ func setupAuthTLS(auth authConfig, saramaCfg *sarama.Config) error {
 	}
 
 	tlsCfg := &tls.Config{RootCAs: caPool, Certificates: []tls.Certificate{clientCert}}
-	tlsCfg.BuildNameToCertificate()
-
 	saramaCfg.Net.TLS.Enable = true
 	saramaCfg.Net.TLS.Config = tlsCfg
 


### PR DESCRIPTION
The tls.Config.BuildNameToCertificate() method has been deprecated since Go 1.14. The name-to-certificate mapping is now built automatically, making manual calls unnecessary.

🤖 Generated with [Claude Code](https://claude.ai/code)