### PR TITLE
tagpr creates a release with a draft status.

### DIFF
--- a/.tagpr
+++ b/.tagpr
@@ -2,3 +2,4 @@
 	vPrefix = true
 	releaseBranch = main
 	versionFile = "main.go"
+	release = draft


### PR DESCRIPTION
https://github.blog/changelog/2025-08-26-releases-now-support-immutability-in-public-preview/

The kt's release flow is,

1. [tagpr](https://github.com/Songmu/tagpr) creates a new release.
2. Goreleaser builds binaries and push to the release.

When the immutability setting is enabled, tagpr must create a release with draft status to add assets by Goreleaser later.
