### PR TITLE
Add cluster info display to admin command

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -52,6 +52,12 @@ jobs:
           echo "TCP connection established, checking Kafka readiness..."
           timeout 60 bash -c 'until docker logs kt-kafka-1 2>&1 | grep -q "Kafka Server started"; do sleep 2; done'
           echo "Kafka is ready!"
+          docker compose logs kafka | grep "Kafka version:"
+
+      - name: kt admin
+        run: |
+          make
+          ./kt admin
 
       - name: Integration Test
         run: |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Some reasons why you might be interested:
 * Adaptive output buffering: unbuffered for terminals, buffered for pipes and files to improve performance.
 * Binary keys and payloads can be passed and presented in base64 or hex encoding.
 * Support for TLS authentication.
-* Basic cluster admin functions: Create & delete topics.
+* Basic cluster admin functions: View cluster information, create & delete topics.
 
 > [!NOTE]
 > This repository is a fork of the original [kt](https://github.com/fgeller/kt).
@@ -249,6 +249,37 @@ $ kt group --group my-group --topic actor-news --partitions 0,1 --reset 100
 # Show offsets without fetching additional data
 $ kt group --group my-group --offsets
 ```
+</details>
+
+<details><summary>View cluster information</summary>
+
+```sh
+$ kt admin
+{
+  "controller_id": 1,
+  "brokers": [
+    {
+      "id": 1,
+      "host": "localhost",
+      "port": 9092,
+      "version": "3.0+"
+    }
+  ]
+}
+
+# With jq filter to get controller ID
+$ kt admin --jq '.controller_id'
+1
+
+# Get list of broker IDs
+$ kt admin --jq '.brokers[].id'
+1
+
+# Get broker versions
+$ kt admin --jq '.brokers[].version'
+"3.0+"
+```
+
 </details>
 
 <details><summary>Create and delete a topic</summary>


### PR DESCRIPTION
## Summary

Extended `kt admin` command to display cluster information by default, including controller ID and broker details (ID, host, port, rack, version).

## Changes

- Added `brokerInfo` and `clusterInfo` structs with `ToMap()` method for JSON serialization
- Implemented `runClusterInfo()` to fetch and display cluster information
- Added `getBrokerVersion()` to detect Kafka version via Metadata API max version
- Modified `admin run()` to call `runClusterInfo()` when no other sub-command is specified
- Updated README with usage examples

## Motivation

This feature allows users to quickly check Kafka cluster status and broker versions without additional tools.